### PR TITLE
✨ 支持在关联动作中使用 `{name}` 占位符

### DIFF
--- a/src/script-generator/strategy.ts
+++ b/src/script-generator/strategy.ts
@@ -33,7 +33,7 @@ export const statementStrategy = [
         if (figureID) {
           const defaultCostume = getDefaultCostume(state.figureRecord[figureID].costumes)
           const figureFile = defaultCostume.path
-          const figureAction = findAction(state.actionLink, action) || settings.figureDefaultAction || 'idle'
+          const figureAction = findAction(state.actionLink, action, figureID) || settings.figureDefaultAction || 'idle'
           const figureMotion = getFigureAction(defaultCostume.motions, figureAction)
           const figureExpression = getFigureAction(defaultCostume.expressions, figureAction)
           const argsMap = {
@@ -80,9 +80,17 @@ function getDefaultCostume(costumes: Costume[]): Costume {
   return randomChoice(costumes)
 }
 
-function findAction(actionLink: ActionLink, key: string): string | undefined {
+function findAction(actionLink: ActionLink, key: string, figureID?: string): string | undefined {
   const item = actionLink.find(obj => obj.key === key)
-  return item?.value
+  if (!item?.value) {
+    return undefined
+  }
+
+  if (figureID && item.value.includes('{name}')) {
+    return item.value.replaceAll('{name}', figureID)
+  }
+
+  return item.value
 }
 
 function getFigureAction(motions: string[], action: string): string {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

允许用户在关联动作中使用 `{name}` 占位符，在生成脚本时会被替换为当前立绘的 figureID。

在关联动作对话框中，用户可以设置：
- 动作名：`微笑`
- 角色动作：`{name}_smile`

当生成脚本时，如果当前角色对应的 figureID 是 `anon`，则会被替换为 `anon_smile`。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

允许用户更灵活的设置关联动作

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
